### PR TITLE
Optionally allow commands to be set on a directory level

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ require('tmux-compile').setup({
             -- missing
         }
     }
+
+    -- Directory override config. [OPTIONAL] 
+    -- If you want to set Run, Build and Debug actions for a specific directory (per project basis)
+    -- Note: do not use '~' for home directory, use full path
+    project_override_config = {
+        {
+            project_base_dir = '/path/to/project',
+            build = 'make',
+            run = 'make run',
+            debug = 'lldb',
+        },
+        {
+            project_base_dir = '/path/to/another/project',
+            build = 'cargo build',
+            -- Only build will work for this path
+        }
+    }
 })
 ```
 

--- a/lua/tmux-compile/actions.lua
+++ b/lua/tmux-compile/actions.lua
@@ -6,7 +6,7 @@ local Actions = {}
 
 --
 -- run command in a new or existing tmux window
-function Actions.new_window(aCmd, aWindowTitle, aErrorName)
+function Actions.new_window(aCmd, aWindowName, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
         print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
@@ -14,7 +14,7 @@ function Actions.new_window(aCmd, aWindowTitle, aErrorName)
         return 1
     end
 
-    if tmux_window_exists(aWindowName) then
+    if Helpers.tmux_window_exists(aWindowName) then
         aCmd = Helpers.change_dir(aWindowName) .. aCmd
 
         vim.fn.system("tmux selectw -t " .. aWindowName .. " \\; send-keys '" .. aCmd .. "' C-m")
@@ -89,7 +89,7 @@ end
 
 --
 -- run lazygit in an overlay pane
-function Actions.lazygit(aWidth, aHeight)
+function Actions.lazygit(aWidth, aHeight, aErrorName)
     if vim.fn.executable("lazygit") == 1 then
         Actions.overlay("lazygit", 0, aWidth, aHeight, aErrorName)
     else

--- a/lua/tmux-compile/actions.lua
+++ b/lua/tmux-compile/actions.lua
@@ -1,110 +1,100 @@
-
 -- Actions.Lua
 
-local Helpers = require( "tmux-compile.helpers" )
+local Helpers = require("tmux-compile.helpers")
 
 local Actions = {}
 
 --
 -- run command in a new or existing tmux window
-function Actions.new_window( aCmd, aWindowTitle, aErrorName )
+function Actions.new_window(aCmd, aWindowTitle, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
 
-    if tmux_window_exists( aWindowName ) then
-        aCmd = Helpers.change_dir( aWindowName ) .. aCmd
+    if tmux_window_exists(aWindowName) then
+        aCmd = Helpers.change_dir(aWindowName) .. aCmd
 
-        vim.fn.system( "tmux selectw -t " .. aWindowName .. " \\; send-keys '" .. aCmd .. "' C-m" )
+        vim.fn.system("tmux selectw -t " .. aWindowName .. " \\; send-keys '" .. aCmd .. "' C-m")
     else
-        local lProjectDir = vim.fn.trim(
-            vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd")
-        ) .. " -n "
+        local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd")) .. " -n "
 
-        vim.fn.system( "tmux neww -c " .. lProjectDir .. aWindowName .. " '" .. aCmd .. "; zsh'")
+        vim.fn.system("tmux neww -c " .. lProjectDir .. aWindowName .. " '" .. aCmd .. "; zsh'")
     end
 end
-
 
 --
 -- run command in an overlay pane
-function Actions.overlay( aCmd, aSleepDuration, aWidth, aHeight, aErrorName )
+function Actions.overlay(aCmd, aSleepDuration, aWidth, aHeight, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
 
-    local lProjectDir = vim.fn.trim(
-        vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd")
-    )
+    local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd"))
 
-    local aCmdHead    = "tmux display-popup -E -d" .. lProjectDir
+    local aCmdHead = "tmux display-popup -E -d" .. lProjectDir
     local lDimensions = " -w " .. aWidth .. "\\% -h " .. aHeight .. "\\% '"
 
-	local lSleep
-	if aSleepDuration < 0 then
-		lSleep = "; read'"
-	else
-		lSleep = "; sleep " .. aSleepDuration .. "'"
-	end
+    local lSleep
+    if aSleepDuration < 0 then
+        lSleep = "; read'"
+    else
+        lSleep = "; sleep " .. aSleepDuration .. "'"
+    end
 
-    vim.fn.system( aCmdHead .. lDimensions .. aCmd .. lSleep )
+    vim.fn.system(aCmdHead .. lDimensions .. aCmd .. lSleep)
 end
-
 
 --
 -- run command in same window on a new pane
-function Actions.split_window( aCmd, aSide, aWidth, aHeight, aNewPane, aErrorName )
+function Actions.split_window(aCmd, aSide, aWidth, aHeight, aNewPane, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
 
     local lDirectionLookup = {
         v = "-D",
-        h = "-R"
+        h = "-R",
     }
 
     local lLengthPercentage = {
         v = aHeight,
-        h = aWidth
+        h = aWidth,
     }
 
-    local lCurrentPane = vim.fn.system( "tmux display -p '#{pane_id}'" )
-    vim.fn.system( "tmux selectp " .. lDirectionLookup[aSide] )
-    local lMovedPane = vim.fn.system( "tmux display -p '#{pane_id}'" )
+    local lCurrentPane = vim.fn.system("tmux display -p '#{pane_id}'")
+    vim.fn.system("tmux selectp " .. lDirectionLookup[aSide])
+    local lMovedPane = vim.fn.system("tmux display -p '#{pane_id}'")
 
-    aCmd = Helpers.change_dir( vim.trim(lMovedPane) ) .. aCmd
+    aCmd = Helpers.change_dir(vim.trim(lMovedPane)) .. aCmd
 
-    if ( vim.trim(lCurrentPane) == vim.trim(lMovedPane) or aNewPane ) then
+    if vim.trim(lCurrentPane) == vim.trim(lMovedPane) or aNewPane then
         local lParameters = aSide .. " -l " .. lLengthPercentage[aSide] .. "%"
         vim.fn.system("tmux splitw -" .. lParameters .. " '" .. aCmd .. "; zsh'")
     else
-        vim.fn.system( "tmux send -t " .. vim.trim(lMovedPane) .. " '" .. aCmd .. "' C-m" )
+        vim.fn.system("tmux send -t " .. vim.trim(lMovedPane) .. " '" .. aCmd .. "' C-m")
     end
 
-	-- return to nvim pane
-	vim.fn.system( "tmux select-pane -l" )
+    -- return to nvim pane
+    vim.fn.system("tmux select-pane -l")
 end
-
 
 --
 -- run lazygit in an overlay pane
-function Actions.lazygit( aWidth, aHeight )
-    if vim.fn.executable( "lazygit" ) == 1 then
-        Actions.overlay( "lazygit", 0, aWidth, aHeight, aErrorName  )
+function Actions.lazygit(aWidth, aHeight)
+    if vim.fn.executable("lazygit") == 1 then
+        Actions.overlay("lazygit", 0, aWidth, aHeight, aErrorName)
     else
-        print( "Error: lazygit not installed." )
+        print("Error: lazygit not installed.")
     end
 end
 
-
 return Actions
-

--- a/lua/tmux-compile/commands.lua
+++ b/lua/tmux-compile/commands.lua
@@ -1,42 +1,67 @@
-
 -- Commands.Lua
 
-local Actions = require( "tmux-compile.actions" )
-local Helpers = require( "tmux-compile.helpers" )
-local Env     = require( "tmux-compile.env" )
+local Actions = require("tmux-compile.actions")
+local Helpers = require("tmux-compile.helpers")
+local Env = require("tmux-compile.env")
 
 local Commands = {}
 
 --
 -- commands dispatch
-function Commands.dispatch( aOption, aConfig )
+function Commands.dispatch(aOption, aConfig)
     if not Env.is_tmux_installed() then
-        print( "Error: install TMUX to use the plugin" )
+        print("Error: install TMUX to use the plugin")
         return 1
     end
 
     if not Env.is_tmux_running() then
-        print( "Error: run session in TMUX" )
+        print("Error: run session in TMUX")
         return 1
     end
 
     if aConfig.save_session then
-        vim.cmd( ":wall" )
+        vim.cmd(":wall")
     end
 
-    local lExtension = Helpers.get_file_extension()
-    local lMake, lRun, lDebug = Helpers.get_commands_for_extension( lExtension, aConfig )
+    local lMake, lRun, lDebug
+
+    local function load_from_extension()
+        local lExtension = Helpers.get_file_extension()
+        lMake, lRun, lDebug = Helpers.get_commands_for_extension(lExtension, aConfig)
+    end
+
+    local lIsDirectoryOverrideSet = aConfig.project_override_config ~= nil
+    local lIsDirectoryOverrideFound = false
+
+    if lIsDirectoryOverrideSet then
+        local lOverrideConfig = Helpers.get_matched_directory_override(aConfig)
+
+        if lOverrideConfig ~= nil then
+            lMake, lRun, lDebug = lOverrideConfig.build, lOverrideConfig.run, lOverrideConfig.debug
+            lIsDirectoryOverrideFound = true
+        else
+            load_from_extension()
+        end
+    else
+        load_from_extension()
+    end
 
     local commands = {
-        Run   = { command = lRun,   title = "Run"   },
-        Make  = { command = lMake,  title = "Make"  },
-        Debug = { command = lDebug, title = "Debug" }
+        Run = { command = lRun, title = "Run" },
+        Make = { command = lMake, title = "Make" },
+        Debug = { command = lDebug, title = "Debug" },
     }
 
-    local function execute_command( cmd, lOrientation, lBackground )
+    local function execute_command(cmd, lOrientation, lBackground)
         local lCommandInfo = commands[cmd]
+
         if not lCommandInfo then
             print("Error: Invalid aOption.")
+            return
+        end
+
+        if lIsDirectoryOverrideFound and lCommandInfo.command == nil then
+            print("Error: override for directory set but no command found.")
             return
         end
 
@@ -46,11 +71,7 @@ function Commands.dispatch( aOption, aConfig )
         end
 
         if lBackground then
-            action(
-                lCommandInfo.command,
-                aConfig.build_run_window_title,
-                lCommandInfo.title
-            )
+            action(lCommandInfo.command, aConfig.build_run_window_title, lCommandInfo.title)
         elseif lOrientation then
             action(
                 lCommandInfo.command,
@@ -62,7 +83,7 @@ function Commands.dispatch( aOption, aConfig )
             )
         else
             action(
-                lCommandInfo.command, 
+                lCommandInfo.command,
                 aConfig.overlay_sleep,
                 aConfig.overlay_width_percent,
                 aConfig.overlay_height_percent,
@@ -72,7 +93,7 @@ function Commands.dispatch( aOption, aConfig )
     end
 
     if aOption == "lazygit" then
-        Actions.lazygit( aConfig.overlay_width_percent, aConfig.overlay_height_percent )
+        Actions.lazygit(aConfig.overlay_width_percent, aConfig.overlay_height_percent)
     else
         local lOrientation = nil
         local lBackground = false
@@ -80,20 +101,16 @@ function Commands.dispatch( aOption, aConfig )
         if aOption:sub(-1) == "V" then
             lOrientation = "v"
             aOption = aOption:sub(1, -2)
-
         elseif aOption:sub(-1) == "H" then
             lOrientation = "h"
             aOption = aOption:sub(1, -2)
-
         elseif aOption:sub(-2) == "BG" then
             lBackground = true
             aOption = aOption:sub(1, -3)
         end
 
-        execute_command( aOption, lOrientation, lBackground )
+        execute_command(aOption, lOrientation, lBackground)
     end
 end
 
 return Commands
-
-

--- a/lua/tmux-compile/helpers.lua
+++ b/lua/tmux-compile/helpers.lua
@@ -1,23 +1,48 @@
-
 -- Helpers.Lua
 
 local Helpers = {}
 
 --
--- get the file extension
-function Helpers.get_file_extension()
-    local lFilename = vim.api.nvim_buf_get_name( 0 )
-    local lExtension = lFilename:match( "^.+(%..+)$" )
+-- get matched directory override config if it exists
+function Helpers.get_matched_directory_override(aConfig)
+    for _, lConfig in ipairs(aConfig.project_override_config) do
+        local lFilename = vim.api.nvim_buf_get_name(0)
 
-    return lExtension and lExtension:sub( 2 ) or "No Extension"
+        if string.match(lFilename, "^" .. vim.pesc(lConfig.project_base_dir)) then
+            return lConfig
+        end
+    end
+
+    return nil
 end
 
+--
+-- get directory override config values
+function Helpers.get_directory_override_commands(aOverrideConfig)
+    local lProjectDir = aOverrideConfig.project_base_dir
+    local lFilename = vim.api.nvim_buf_get_name(0)
+
+    if string.find(lFilename, lProjectDir) then
+        return aOverrideConfig.build, aOverrideConfig.run, aOverrideConfig.debug
+    else
+        return nil, nil, nil
+    end
+end
+
+--
+-- get the file extension
+function Helpers.get_file_extension()
+    local lFilename = vim.api.nvim_buf_get_name(0)
+    local lExtension = lFilename:match("^.+(%..+)$")
+
+    return lExtension and lExtension:sub(2) or "No Extension"
+end
 
 --
 -- get build, run & debug commands based on file extension
-function Helpers.get_commands_for_extension( aExtension, aConfig )
-    for _, lConfig in ipairs( aConfig.build_run_config ) do
-        if vim.tbl_contains( lConfig.extension, aExtension ) then
+function Helpers.get_commands_for_extension(aExtension, aConfig)
+    for _, lConfig in ipairs(aConfig.build_run_config) do
+        if vim.tbl_contains(lConfig.extension, aExtension) then
             return lConfig.build, lConfig.run, lConfig.debug
         end
     end
@@ -25,35 +50,27 @@ function Helpers.get_commands_for_extension( aExtension, aConfig )
     return nil, nil, nil
 end
 
-
 --
 -- check if a tmux window with the given name exists
-function Helpers.tmux_window_exists( aWindowName )
-    local Result = vim.fn.system( "tmux list-windows | grep -w " .. aWindowName )
+function Helpers.tmux_window_exists(aWindowName)
+    local Result = vim.fn.system("tmux list-windows | grep -w " .. aWindowName)
 
     return Result ~= ""
 end
 
-
 --
 -- change directory if not same as project
-function Helpers.change_dir( aPane )
-    local lProjectDir = vim.fn.trim(
-        vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd")
-    )
+function Helpers.change_dir(aPane)
+    local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd"))
     print(lProjectDir)
 
-    local lWindowDir = vim.fn.trim(
-        vim.fn.system( "tmux display -p -t " .. aPane .. " '#{pane_current_path}'" )
-    )
+    local lWindowDir = vim.fn.trim(vim.fn.system("tmux display -p -t " .. aPane .. " '#{pane_current_path}'"))
 
-    if lWindowDir == lProjectDir or lWindowDir == ( "/private" .. lProjectDir ) then
+    if lWindowDir == lProjectDir or lWindowDir == ("/private" .. lProjectDir) then
         return ""
     end
 
     return "cd " .. lProjectDir .. "; "
 end
 
-
 return Helpers
-

--- a/lua/tmux-compile/init.lua
+++ b/lua/tmux-compile/init.lua
@@ -1,7 +1,6 @@
-
 -- init.lua
 
-local Commands = require( "tmux-compile.commands" )
+local Commands = require("tmux-compile.commands")
 
 local M = {}
 M.config = {
@@ -13,29 +12,37 @@ M.config = {
     overlay_sleep = -1,
     overlay_width_percent = 80,
     overlay_height_percent = 80,
-    build_run_config = {}
+    build_run_config = {},
 }
 
-function M.setup( aConfig )
-    for key, value in pairs( aConfig ) do
+function M.setup(aConfig)
+    for key, value in pairs(aConfig) do
         M.config[key] = value or M.config[key]
     end
 end
 
 -- nvim command integration
-vim.api.nvim_create_user_command( 'TMUXcompile', function(args)
-    Commands.dispatch( args.args, M.config )
+vim.api.nvim_create_user_command("TMUXcompile", function(args)
+    Commands.dispatch(args.args, M.config)
 end, {
     nargs = 1,
     complete = function()
         return {
             "lazygit",
-            "Run", "RunV", "RunH", "RunBG",
-            "Make", "MakeV", "MakeH", "MakeBG",
-            "Debug", "DebugV", "DebugH", "DebugBG"
+            "Run",
+            "RunV",
+            "RunH",
+            "RunBG",
+            "Make",
+            "MakeV",
+            "MakeH",
+            "MakeBG",
+            "Debug",
+            "DebugV",
+            "DebugH",
+            "DebugBG",
         }
     end,
 })
 
 return M
-

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,2 +1,3 @@
 indent_width = 4 
+indent_type = "Spaces"
 quote_style = "AutoPreferDouble"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,4 +1,2 @@
-[format]
-indent = 4
-line_width = 100
-quote_style = Auto
+indent_width = 4 
+quote_style = "AutoPreferDouble"


### PR DESCRIPTION
### Allow users to optionally set commands on a directory/project level. 

#### This will allow the program to work as expected when the buffer with the proper extension is not currently open as well as allow users to setup specific commands for heterogeneous projects (Hugo for example). 

Expose a new ``` project_override_config``` field inside the config with Lua tables for each individual directory.

The code will check if the current buffer matches any of the specified directory roots and if so it will execute the provided command with the current mechanism. 
If a directory root is set but a command is not, it will print the proper error message.

If a directory root is not found for the current buffer it will fallback to the extensions configuration.

***Note***. I've also updated stylua.toml according to the readme from the [official repo](https://github.com/JohnnyMorganz/StyLua) as none-ls was not working with the provided one.