### PR TITLE
Support for defining project override configs in the project directory (instead of the nvim config directory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ within current Neovim session on an overlay terminal.
 
 Install using your favorite plugin manager. For example, using
 [lazy.nvim](https://github.com/folke/lazy.nvim):
+
 ```lua
 { 'karshPrime/tmux-compile.nvim', event = 'VeryLazy' },
 ```
+
 And setup it with:
+
 ```lua
 require('tmux-compile').setup({
     -- Overriding Default Configurations. [OPTIONAL]
@@ -58,7 +61,7 @@ require('tmux-compile').setup({
         }
     },
 
-    -- Directory override config. [OPTIONAL] 
+    -- Directory override config. [OPTIONAL]
     -- Set actions for a specific directory (per project basis)
     project_override_config = {
         {
@@ -74,6 +77,31 @@ require('tmux-compile').setup({
             -- Only build will work for this path
         }
     }
+
+
+    -- Defining project overrides locally.
+    -- Along with the previously defined 'project_override_config' it is also possible to define build/run/debug actions
+    -- locally inside the project working directory.
+    -- The plugin will look for a configuratino file called 'tmux-compile.lua' inside the following directories
+    -- RELATIVE to the vim current owrking directory:
+    -- ./.nvim/
+    -- ./nvim/
+    -- ./
+    -- example tmux-compile.lua file
+
+    return {
+        build = "make",
+        run = "make run"
+    }
+
+    -- IMPORTANT: configuration precedence
+    -- When starting, this plugin will load and apply the build/run/debug commands in the following order
+
+    -- 1. tmux-compile.lua
+    -- 2. project_override_config
+    -- 3. build_run_config
+
+    -- If there is no tmux-compile.lua file defined in the current working directory, the plugin will load the commands from the 'project_override_config' table inside the main config. If that is also not defined for the current working directory, then the plugin will default to the commands defined by the file extension of the current buffer
 })
 
 ```
@@ -85,29 +113,31 @@ Create keybindings for any command by adding the following to Neovim config:
 ```lua
 vim.keymap.set('n', 'KEYBIND', 'COMMAND<CR>', {silent=true})
 ```
+
 Example: to set F5 to compile and run current project in an overlay terminal
 window-
+
 ```lua
 vim.keymap.set('n','<F5>', ':TMUXcompile Run<CR>', {silent=true})
 ```
 
 ### List of all supported commands
 
-| Action / Purpose                                        | Command               |
-|---------------------------------------------------------|-----------------------|
-| Compile program in an overlay terminal window           | `:TMUXcompile Make`   |
-| Compile program in a new tmux window                    | `:TMUXcompile MakeBG` |
-| Compile program in a new pane next to current nvim pane | `:TMUXcompile MakeV`  |
-| Compile program in a new pane bellow current nvim pane  | `:TMUXcompile MakeH`  |
-| Run program in an overlay terminal window               | `:TMUXcompile Run`    |
-| Run program in a tmux new window                        | `:TMUXcompile RunBG`  |
-| Run program in a new pane next to current nvim pane     | `:TMUXcompile RunV`   |
-| Run program in a new pane bellow current nvim pane      | `:TMUXcompile RunH`   |
-| Start debugger in an overlay terminal window            | `:TMUXcompile Debug`  |
-| Start debugger in a tmux new window                     | `:TMUXcompile DebugBG`|
-| Start debugger in a new pane next to current nvim pane  | `:TMUXcompile DebugV` |
-| Start debugger in a new pane bellow current nvim pane   | `:TMUXcompile DebugH` |
-| Open lazygit in overlay                                 | `:TMUXcompile lazygit`|
+| Action / Purpose                                        | Command                |
+| ------------------------------------------------------- | ---------------------- |
+| Compile program in an overlay terminal window           | `:TMUXcompile Make`    |
+| Compile program in a new tmux window                    | `:TMUXcompile MakeBG`  |
+| Compile program in a new pane next to current nvim pane | `:TMUXcompile MakeV`   |
+| Compile program in a new pane bellow current nvim pane  | `:TMUXcompile MakeH`   |
+| Run program in an overlay terminal window               | `:TMUXcompile Run`     |
+| Run program in a tmux new window                        | `:TMUXcompile RunBG`   |
+| Run program in a new pane next to current nvim pane     | `:TMUXcompile RunV`    |
+| Run program in a new pane bellow current nvim pane      | `:TMUXcompile RunH`    |
+| Start debugger in an overlay terminal window            | `:TMUXcompile Debug`   |
+| Start debugger in a tmux new window                     | `:TMUXcompile DebugBG` |
+| Start debugger in a new pane next to current nvim pane  | `:TMUXcompile DebugV`  |
+| Start debugger in a new pane bellow current nvim pane   | `:TMUXcompile DebugH`  |
+| Open lazygit in overlay                                 | `:TMUXcompile lazygit` |
 
 \* **Run** here includes both compiling and running the program, depending on the
 run command specified for the file extension.
@@ -124,4 +154,3 @@ previously unnamed list, resulting in incompatibility with older configurations.
 Apologies for any inconvenience this may cause. From version 2, the plugin has been
 designed with future-proofing in mind to ensure that such issues do not recur.
 </details>
-

--- a/lua/tmux-compile/actions.lua
+++ b/lua/tmux-compile/actions.lua
@@ -9,7 +9,7 @@ local Actions = {}
 function Actions.new_window(aCmd, aWindowName, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
+        vim.notify("Error: " .. aErrorName .. " command not found for ." .. lExtension, vim.log.levels.ERROR)
 
         return 1
     end
@@ -30,7 +30,7 @@ end
 function Actions.overlay(aCmd, aSleepDuration, aWidth, aHeight, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
+        vim.notify("Error: " .. aErrorName .. " command not found for ." .. lExtension, vim.log.levels.ERROR)
 
         return 1
     end
@@ -55,7 +55,7 @@ end
 function Actions.split_window(aCmd, aSide, aWidth, aHeight, aNewPane, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
+        vim.notify("Error: " .. aErrorName .. " command not found for ." .. lExtension, vim.log.levels.ERROR)
 
         return 1
     end
@@ -93,7 +93,7 @@ function Actions.yazi(aWidth, aHeight, aErrorName)
     if vim.fn.executable("yazi") == 1 then
         Actions.overlay("yazi", 0, aWidth, aHeight, aErrorName)
     else
-        print("Error: yazi not installed.")
+        vim.notify("Error: yazi not installed.", vim.log.levels.ERROR)
     end
 end
 --
@@ -102,7 +102,7 @@ function Actions.lazygit(aWidth, aHeight, aErrorName)
     if vim.fn.executable("lazygit") == 1 then
         Actions.overlay("lazygit", 0, aWidth, aHeight, aErrorName)
     else
-        print("Error: lazygit not installed.")
+        vim.notify("Error: lazygit not installed.", vim.log.levels.ERROR)
     end
 end
 

--- a/lua/tmux-compile/actions.lua
+++ b/lua/tmux-compile/actions.lua
@@ -1,46 +1,41 @@
-
 -- Actions.Lua
 
-local Helpers = require( "tmux-compile.helpers" )
+local Helpers = require("tmux-compile.helpers")
 
 local Actions = {}
 
 --
 -- run command in a new or existing tmux window
-function Actions.new_window( aCmd, aWindowName, aErrorName )
+function Actions.new_window(aCmd, aWindowName, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
 
-    if Helpers.tmux_window_exists( aWindowName ) then
-        aCmd = Helpers.change_dir( aWindowName ) .. aCmd
+    if Helpers.tmux_window_exists(aWindowName) then
+        aCmd = Helpers.change_dir(aWindowName) .. aCmd
 
-        vim.fn.system( "tmux selectw -t " .. aWindowName .. " \\; send-keys '" .. aCmd .. "' C-m" )
+        vim.fn.system("tmux selectw -t " .. aWindowName .. " \\; send-keys '" .. aCmd .. "' C-m")
     else
-        local lProjectDir = vim.fn.trim(
-            vim.fn.system( "git rev-parse --show-toplevel 2>/dev/null || pwd" )
-        ) .. " -n "
+        local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd")) .. " -n "
 
-        vim.fn.system( "tmux neww -c " .. lProjectDir .. aWindowName .. " '" .. aCmd .. "; zsh'" )
+        vim.fn.system("tmux neww -c " .. lProjectDir .. aWindowName .. " '" .. aCmd .. "; zsh'")
     end
 end
 
 --
 -- run command in an overlay pane
-function Actions.overlay( aCmd, aSleepDuration, aWidth, aHeight, aErrorName )
+function Actions.overlay(aCmd, aSleepDuration, aWidth, aHeight, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
 
-    local lProjectDir = vim.fn.trim(
-        vim.fn.system( "git rev-parse --show-toplevel 2>/dev/null || pwd" )
-    )
+    local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd"))
 
     local aCmdHead = "tmux display-popup -E -d" .. lProjectDir
     local lDimensions = " -w " .. aWidth .. "\\% -h " .. aHeight .. "\\% '"
@@ -52,15 +47,15 @@ function Actions.overlay( aCmd, aSleepDuration, aWidth, aHeight, aErrorName )
         lSleep = "; sleep " .. aSleepDuration .. "'"
     end
 
-    vim.fn.system( aCmdHead .. lDimensions .. aCmd .. lSleep )
+    vim.fn.system(aCmdHead .. lDimensions .. aCmd .. lSleep)
 end
 
 --
 -- run command in same window on a new pane
-function Actions.split_window( aCmd, aSide, aWidth, aHeight, aNewPane, aErrorName )
+function Actions.split_window(aCmd, aSide, aWidth, aHeight, aNewPane, aErrorName)
     if not aCmd then
         local lExtension = Helpers.get_file_extension()
-        print( "Error: " .. aErrorName .. " command not found for ." .. lExtension )
+        print("Error: " .. aErrorName .. " command not found for ." .. lExtension)
 
         return 1
     end
@@ -75,32 +70,40 @@ function Actions.split_window( aCmd, aSide, aWidth, aHeight, aNewPane, aErrorNam
         h = aWidth,
     }
 
-    local lCurrentPane = vim.fn.system( "tmux display -p '#{pane_id}'" )
-    vim.fn.system( "tmux selectp " .. lDirectionLookup[aSide] )
-    local lMovedPane = vim.fn.system( "tmux display -p '#{pane_id}'" )
+    local lCurrentPane = vim.fn.system("tmux display -p '#{pane_id}'")
+    vim.fn.system("tmux selectp " .. lDirectionLookup[aSide])
+    local lMovedPane = vim.fn.system("tmux display -p '#{pane_id}'")
 
-    aCmd = Helpers.change_dir( vim.trim(lMovedPane) ) .. aCmd
+    aCmd = Helpers.change_dir(vim.trim(lMovedPane)) .. aCmd
 
-    if vim.trim( lCurrentPane ) == vim.trim( lMovedPane ) or aNewPane then
+    if vim.trim(lCurrentPane) == vim.trim(lMovedPane) or aNewPane then
         local lParameters = aSide .. " -l " .. lLengthPercentage[aSide] .. "%"
-        vim.fn.system( "tmux splitw -" .. lParameters .. " '" .. aCmd .. "; zsh'" )
+        vim.fn.system("tmux splitw -" .. lParameters .. " '" .. aCmd .. "; zsh'")
     else
-        vim.fn.system( "tmux send -t " .. vim.trim( lMovedPane ) .. " '" .. aCmd .. "' C-m" )
+        vim.fn.system("tmux send -t " .. vim.trim(lMovedPane) .. " '" .. aCmd .. "' C-m")
     end
 
     -- return to nvim pane
-    vim.fn.system( "tmux select-pane -l" )
+    vim.fn.system("tmux select-pane -l")
 end
 
 --
--- run lazygit in an overlay pane
-function Actions.lazygit( aWidth, aHeight, aErrorName )
-    if vim.fn.executable( "lazygit" ) == 1 then
-        Actions.overlay( "lazygit", 0, aWidth, aHeight, aErrorName )
+-- run yazi in an overlay pane
+function Actions.yazi(aWidth, aHeight, aErrorName)
+    if vim.fn.executable("yazi") == 1 then
+        Actions.overlay("yazi", 0, aWidth, aHeight, aErrorName)
     else
-        print( "Error: lazygit not installed." )
+        print("Error: yazi not installed.")
+    end
+end
+--
+-- run lazygit in an overlay pane
+function Actions.lazygit(aWidth, aHeight, aErrorName)
+    if vim.fn.executable("lazygit") == 1 then
+        Actions.overlay("lazygit", 0, aWidth, aHeight, aErrorName)
+    else
+        print("Error: lazygit not installed.")
     end
 end
 
 return Actions
-

--- a/lua/tmux-compile/commands.lua
+++ b/lua/tmux-compile/commands.lua
@@ -1,68 +1,74 @@
-
 -- Commands.Lua
 
-local Actions = require( "tmux-compile.actions" )
-local Helpers = require( "tmux-compile.helpers" )
-local Env = require( "tmux-compile.env" )
+local Actions = require("tmux-compile.actions")
+local Helpers = require("tmux-compile.helpers")
+local Env = require("tmux-compile.env")
 
 local Commands = {}
 
 --
 -- commands dispatch
-function Commands.dispatch( aOption, aConfig )
+function Commands.dispatch(aOption, aConfig)
     if not Env.is_tmux_installed() then
-        print( "Error: install TMUX to use the plugin" )
+        print("Error: install TMUX to use the plugin")
         return 1
     end
 
     if not Env.is_tmux_running() then
-        print( "Error: run session in TMUX" )
+        print("Error: run session in TMUX")
         return 1
     end
 
     if aConfig.save_session then
-        vim.cmd( ":wall" )
+        vim.cmd(":wall")
     end
 
     local lMake, lRun, lDebug
 
     local function load_from_extension()
-        local lExtension    = Helpers.get_file_extension()
-        lMake, lRun, lDebug = Helpers.get_commands_for_extension( lExtension, aConfig )
+        local lExtension = Helpers.get_file_extension()
+        lMake, lRun, lDebug = Helpers.get_commands_for_extension(lExtension, aConfig)
     end
 
-    local lIsDirectoryOverrideSet   = aConfig.project_override_config ~= nil
     local lIsDirectoryOverrideFound = false
 
-    if lIsDirectoryOverrideSet then
-        local lOverrideConfig = Helpers.get_matched_directory_override( aConfig )
+    if aConfig.override_config_from_project then
+        local lOverrideConfig = aConfig.project_override_config
+        lMake, lRun, lDebug = lOverrideConfig.build, lOverrideConfig.run, lOverrideConfig.debug
+        lIsDirectoryOverrideFound = true
+    else
+        local lIsDirectoryOverrideSet = aConfig.project_override_config ~= nil
 
-        if lOverrideConfig ~= nil then
-            lMake, lRun, lDebug = lOverrideConfig.build, lOverrideConfig.run, lOverrideConfig.debug
-            lIsDirectoryOverrideFound = true
+        if lIsDirectoryOverrideSet then
+            local lOverrideConfig = Helpers.get_matched_directory_override(aConfig)
+
+            if lOverrideConfig ~= nil then
+                lMake, lRun, lDebug = lOverrideConfig.build, lOverrideConfig.run, lOverrideConfig.debug
+                lIsDirectoryOverrideFound = true
+            else
+                load_from_extension()
+            end
         else
             load_from_extension()
         end
-    else
-        load_from_extension()
     end
 
     local commands = {
-        Run   = { command = lRun,   title = "Run"   },
-        Make  = { command = lMake,  title = "Make"  },
+        Run = { command = lRun, title = "Run" },
+        Make = { command = lMake, title = "Make" },
         Debug = { command = lDebug, title = "Debug" },
     }
 
-    local function execute_command( cmd, lOrientation, lBackground )
+    local function execute_command(cmd, lOrientation, lBackground)
         local lCommandInfo = commands[cmd]
 
         if not lCommandInfo then
-            print( "Error: Invalid aOption." )
+            print("Error: Invalid aOption.")
             return
         end
 
         if lIsDirectoryOverrideFound and lCommandInfo.command == nil then
-            print( "Error: override for directory set but no command found." )
+            print("Error: override for directory set but no command found.")
             return
         end
 
@@ -72,7 +78,7 @@ function Commands.dispatch( aOption, aConfig )
         end
 
         if lBackground then
-            action( lCommandInfo.command, aConfig.build_run_window_title, lCommandInfo.title )
+            action(lCommandInfo.command, aConfig.build_run_window_title, lCommandInfo.title)
         elseif lOrientation then
             action(
                 lCommandInfo.command,
@@ -94,7 +100,6 @@ function Commands.dispatch( aOption, aConfig )
     end
 
     if aOption == "lazygit" then
-        Actions.lazygit( aConfig.overlay_width_percent, aConfig.overlay_height_percent )
         Actions.lazygit(aConfig.overlay_width_percent, aConfig.overlay_height_percent)
     elseif aOption == "yazi" then
         Actions.yazi(aConfig.overlay_width_percent, aConfig.overlay_height_percent)
@@ -102,20 +107,19 @@ function Commands.dispatch( aOption, aConfig )
         local lOrientation = nil
         local lBackground = false
 
-        if aOption:sub( -1 ) == "V" then
+        if aOption:sub(-1) == "V" then
             lOrientation = "v"
-            aOption = aOption:sub( 1, -2 )
-        elseif aOption:sub( -1 ) == "H" then
+            aOption = aOption:sub(1, -2)
+        elseif aOption:sub(-1) == "H" then
             lOrientation = "h"
-            aOption = aOption:sub( 1, -2 )
-        elseif aOption:sub( -2 ) == "BG" then
+            aOption = aOption:sub(1, -2)
+        elseif aOption:sub(-2) == "BG" then
             lBackground = true
-            aOption = aOption:sub( 1, -3 )
+            aOption = aOption:sub(1, -3)
         end
 
-        execute_command( aOption, lOrientation, lBackground )
+        execute_command(aOption, lOrientation, lBackground)
     end
 end
 
 return Commands
-

--- a/lua/tmux-compile/commands.lua
+++ b/lua/tmux-compile/commands.lua
@@ -95,6 +95,9 @@ function Commands.dispatch( aOption, aConfig )
 
     if aOption == "lazygit" then
         Actions.lazygit( aConfig.overlay_width_percent, aConfig.overlay_height_percent )
+        Actions.lazygit(aConfig.overlay_width_percent, aConfig.overlay_height_percent)
+    elseif aOption == "yazi" then
+        Actions.yazi(aConfig.overlay_width_percent, aConfig.overlay_height_percent)
     else
         local lOrientation = nil
         local lBackground = false

--- a/lua/tmux-compile/helpers.lua
+++ b/lua/tmux-compile/helpers.lua
@@ -1,22 +1,59 @@
-
 -- Helpers.Lua
 
 local Helpers = {}
 
 --
--- get matched directory override config if it exists
-function Helpers.get_matched_directory_override( aConfig )
-    local lFilename = vim.api.nvim_buf_get_name( 0 )
-    local lHomeDir  = os.getenv("HOME")
+-- search for directory override config in project directory
+function Helpers.search_project_defined_override_config(notify_missing_config)
+    local lCwd = vim.fn.getcwd()
+    local lFileName = "tmux-compile.lua"
+    local lPathsToSearch = { "/.nvim", "/nvim", "" }
 
-    for _, lConfig in ipairs( aConfig.project_override_config ) do
+    for _, lPath in ipairs(lPathsToSearch) do
+        local lFullPath = lCwd .. lPath .. "/" .. lFileName
+
+        if vim.fn.filereadable(lFullPath) == 1 then
+            vim.notify("Found TmuxCompile config file at " .. lFullPath, vim.log.levels.INFO)
+            local lSuccess, lResult = pcall(dofile, lFullPath)
+
+            if lSuccess then
+                return lResult
+            else
+                vim.notify("Error loading TmuxCompile config file: " .. lResult, vim.log.levels.ERROR)
+            end
+        end
+    end
+
+    local lPathsSearched = vim.tbl_map(function(aPath)
+        return lCwd .. aPath .. "/" .. lFileName
+    end, lPathsToSearch)
+
+    if notify_missing_config then
+        vim.notify(
+            "Did not find TMUXCompile config file or it is not readable. Paths searched:  "
+                .. table.concat(lPathsSearched, "\n"),
+            vim.log.levels.INFO
+        )
+    end
+    return nil
+end
+
+--
+-- get matched directory override config if it exists
+function Helpers.get_matched_directory_override(aConfig)
+    local lFilename = vim.api.nvim_buf_get_name(0)
+    local lHomeDir = os.getenv("HOME")
+
+    for _, lConfig in ipairs(aConfig.project_override_config) do
         local lConfigDir = lConfig.project_base_dir
 
         if lConfigDir:sub(1, 1) == "~" then
             lConfigDir = lHomeDir .. lConfigDir:sub(2)
         end
 
-        if string.match( lFilename, "^" .. vim.pesc(lConfigDir) ) then
+        vim.notify("Checking if " .. lFilename .. " matches " .. vim.pesc(lConfigDir), vim.log.levels.INFO)
+
+        if string.match(lFilename, "^" .. vim.pesc(lConfigDir)) then
             return lConfig
         end
     end
@@ -26,11 +63,11 @@ end
 
 --
 -- get directory override config values
-function Helpers.get_directory_override_commands( aOverrideConfig )
+function Helpers.get_directory_override_commands(aOverrideConfig)
     local lProjectDir = aOverrideConfig.project_base_dir
-    local lFilename   = vim.api.nvim_buf_get_name( 0 )
+    local lFilename = vim.api.nvim_buf_get_name(0)
 
-    if string.find( lFilename, lProjectDir ) then
+    if string.find(lFilename, lProjectDir) then
         return aOverrideConfig.build, aOverrideConfig.run, aOverrideConfig.debug
     else
         return nil, nil, nil
@@ -40,17 +77,17 @@ end
 --
 -- get the file extension
 function Helpers.get_file_extension()
-    local lFilename  = vim.api.nvim_buf_get_name( 0 )
-    local lExtension = lFilename:match( "^.+( %..+ )$" )
+    local lFilename = vim.api.nvim_buf_get_name(0)
+    local lExtension = lFilename:match("^.+(%..+)$")
 
-    return lExtension and lExtension:sub( 2 ) or "No Extension"
+    return lExtension and lExtension:sub(2) or "No Extension"
 end
 
 --
 -- get build, run & debug commands based on file extension
-function Helpers.get_commands_for_extension( aExtension, aConfig )
-    for _, lConfig in ipairs( aConfig.build_run_config ) do
-        if vim.tbl_contains( lConfig.extension, aExtension ) then
+function Helpers.get_commands_for_extension(aExtension, aConfig)
+    for _, lConfig in ipairs(aConfig.build_run_config) do
+        if vim.tbl_contains(lConfig.extension, aExtension) then
             return lConfig.build, lConfig.run, lConfig.debug
         end
     end
@@ -60,25 +97,21 @@ end
 
 --
 -- check if a tmux window with the given name exists
-function Helpers.tmux_window_exists( aWindowName )
-    local Result = vim.fn.system( "tmux list-windows | grep -w " .. aWindowName )
+function Helpers.tmux_window_exists(aWindowName)
+    local Result = vim.fn.system("tmux list-windows | grep -w " .. aWindowName)
 
     return Result ~= ""
 end
 
 --
 -- change directory if not same as project
-function Helpers.change_dir( aPane )
-    local lProjectDir = vim.fn.trim(
-        vim.fn.system( "git rev-parse --show-toplevel 2>/dev/null || pwd" )
-    )
-    print( lProjectDir )
+function Helpers.change_dir(aPane)
+    local lProjectDir = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel 2>/dev/null || pwd"))
+    print(lProjectDir)
 
-    local lWindowDir = vim.fn.trim(
-        vim.fn.system( "tmux display -p -t " .. aPane .. " '#{pane_current_path}'" )
-    )
+    local lWindowDir = vim.fn.trim(vim.fn.system("tmux display -p -t " .. aPane .. " '#{pane_current_path}'"))
 
-    if lWindowDir == lProjectDir or lWindowDir == ( "/private" .. lProjectDir ) then
+    if lWindowDir == lProjectDir or lWindowDir == ("/private" .. lProjectDir) then
         return ""
     end
 
@@ -86,4 +119,3 @@ function Helpers.change_dir( aPane )
 end
 
 return Helpers
-

--- a/lua/tmux-compile/init.lua
+++ b/lua/tmux-compile/init.lua
@@ -32,6 +32,7 @@ vim.api.nvim_create_user_command(
         nargs = 1,
         complete = function()
         return {
+            "yazi",
             "lazygit",
             "Run",
             "RunV",

--- a/lua/tmux-compile/init.lua
+++ b/lua/tmux-compile/init.lua
@@ -1,7 +1,7 @@
-
 -- init.lua
 
-local Commands = require( "tmux-compile.commands" )
+local Commands = require("tmux-compile.commands")
+local Helpers = require("tmux-compile.helpers")
 
 local M = {}
 M.config = {
@@ -14,23 +14,29 @@ M.config = {
     overlay_width_percent = 80,
     overlay_height_percent = 80,
     build_run_config = {},
+    notify_missing_project_config = false,
 }
 
-function M.setup( aConfig )
-    for key, value in pairs( aConfig ) do
+function M.setup(aConfig)
+    for key, value in pairs(aConfig) do
         M.config[key] = value or M.config[key]
+    end
+
+    local lLocalConfig = Helpers.search_project_defined_override_config(M.config["notify_missing_project_config"])
+    if lLocalConfig ~= nil then
+        M.config["project_override_config"] = lLocalConfig
+        M.config["override_config_from_project"] = true
+    else
+        M.config["override_config_from_project"] = false
     end
 end
 
 -- nvim command integration
-vim.api.nvim_create_user_command(
-    "TMUXcompile",
-    function( args )
-    Commands.dispatch( args.args, M.config )
-    end,
-    {
-        nargs = 1,
-        complete = function()
+vim.api.nvim_create_user_command("TMUXcompile", function(args)
+    Commands.dispatch(args.args, M.config)
+end, {
+    nargs = 1,
+    complete = function()
         return {
             "yazi",
             "lazygit",
@@ -48,8 +54,6 @@ vim.api.nvim_create_user_command(
             "DebugBG",
         }
     end,
-    }
-)
+})
 
 return M
-


### PR DESCRIPTION
The PR encompasses a few things. 

The main feature here is the ability to define the project override config in the project directory itself. 
So, instead of having the navigate to the nvim configuration file and update the configuration of tmux-compile itself every time we want to add a new project, we simply define a 'tmux-compile.lua' file, either in the current working directory directly, or in subfolders '.nvim' or 'nvim'.

If the file is not defined the plugin still falls back looking for the project_override_config defined in the main configuration, and if it doesn't match the path there, it falls back to the file extension behavior. 

Also, I've changed the vim.print commands to be vim.notify commands in order to better communicate to the user when they've made a configuration mistake.

And I've also added another command 'yazi'. Simillar to the 'lazygit' command, it opens the yazi TUI file manager in an overlay window.

P.S. The one conflict I've purposefully left unresolved as I would like your comment. I've modified the regex as it was not properly detecting .lua extensions but am not sure why it was not working in the first place.

Cheers